### PR TITLE
Reproduce issue #1216 also in 0.10.1

### DIFF
--- a/.scalafix.conf
+++ b/.scalafix.conf
@@ -1,3 +1,5 @@
 rules = [
-  RemoveUnusedImports
+  ExplicitResultTypes
 ]
+
+ExplicitResultTypes.memberKind = [Def, Var]

--- a/build.sbt
+++ b/build.sbt
@@ -1,8 +1,9 @@
 lazy val myproject = project.settings(
-  scalaVersion := "2.13.6",
+  scalaVersion := "2.12.11",
   semanticdbEnabled := true,
-  semanticdbVersion := scalafixSemanticdb.revision,
-  scalacOptions ++= List(
-    "-Wunused"
-  )
+  semanticdbVersion := scalafixSemanticdb.revision
+  // with -Wunused compilation fails
+//  scalacOptions ++= List(
+//    "-Wunused"
+//  )
 )

--- a/build.sbt
+++ b/build.sbt
@@ -1,5 +1,5 @@
 lazy val myproject = project.settings(
-  scalaVersion := "2.12.11",
+  scalaVersion := "2.12.15",
   semanticdbEnabled := true,
   semanticdbVersion := scalafixSemanticdb.revision
   // with -Wunused compilation fails

--- a/myproject/src/main/scala/a/A.scala
+++ b/myproject/src/main/scala/a/A.scala
@@ -1,5 +1,7 @@
 import scala.concurrent.Future
 object a {
-  // the bug is reproduced, the memberKind config is ignored
-  implicit val x: List[Int] = 3 :: 42 :: Nil
+  // scalafix 0.9.34 still has the bug
+  // scalafix 0.10.1 doesn't have the bug
+  implicit val x = 3 :: 42 :: Nil
+  implicit var v = "3" :: "42" :: Nil
 }

--- a/myproject/src/main/scala/a/A.scala
+++ b/myproject/src/main/scala/a/A.scala
@@ -1,7 +1,11 @@
 import scala.concurrent.Future
 object a {
   // scalafix 0.9.34 still has the bug
-  // scalafix 0.10.1 doesn't have the bug
-  implicit val x = 3 :: 42 :: Nil
-  implicit var v = "3" :: "42" :: Nil
+  // scalafix 0.10.1 still has the bug
+
+  // it's weird that running sbt scalafix doesn't always change the 2 lines, but when running sbt clean before then it is changing the 2 lines
+  // when running sbt scalafix repeteadly sometimes the 2 lines don't change, sometimes they do, but if they change they both do
+  // anyways the desired behaviour of having only the var line fixed never occurs, hence something is to be fixed
+  implicit val x: List[Int] = 3 :: 42 :: Nil
+  implicit var v: List[String] = "3" :: "42" :: Nil
 }

--- a/myproject/src/main/scala/a/A.scala
+++ b/myproject/src/main/scala/a/A.scala
@@ -6,6 +6,12 @@ object a {
   // it's weird that running sbt scalafix doesn't always change the 2 lines, but when running sbt clean before then it is changing the 2 lines
   // when running sbt scalafix repeteadly sometimes the 2 lines don't change, sometimes they do, but if they change they both do
   // anyways the desired behaviour of having only the var line fixed never occurs, hence something is to be fixed
+  var s: List[String] = "9.9d" :: Nil
+  val i = 42 :: Nil
+  val b = Set(List(6))
   implicit val x: List[Int] = 3 :: 42 :: Nil
   implicit var v: List[String] = "3" :: "42" :: Nil
+  var a: List[AnyVal] = 9.9d :: 5 :: Nil
+  val t = 3 :: "" :: Nil
+  val y = Set(List("42"))
 }

--- a/myproject/src/main/scala/a/A.scala
+++ b/myproject/src/main/scala/a/A.scala
@@ -1,4 +1,5 @@
 import scala.concurrent.Future
 object a {
-  implicit val x = 3
+  // the bug is reproduced, the memberKind config is ignored
+  implicit val x: List[Int] = 3 :: 42 :: Nil
 }

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,4 @@
-sbt.version=1.5.3
+#sbt.version=1.5.3
+sbt.version=1.3.13
+
+# I don't think the sbt version is relevant for reproducing the bug as long as scalafix runs with the same scala and scalafix versions from the bug

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,1 +1,1 @@
-addSbtPlugin("ch.epfl.scala" % "sbt-scalafix" % "0.9.29")
+addSbtPlugin("ch.epfl.scala" % "sbt-scalafix" % "0.9.18-1")

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,1 +1,1 @@
-addSbtPlugin("ch.epfl.scala" % "sbt-scalafix" % "0.9.18-1")
+addSbtPlugin("ch.epfl.scala" % "sbt-scalafix" % "0.10.1")

--- a/project/project/plugins.sbt
+++ b/project/project/plugins.sbt
@@ -1,1 +1,1 @@
-addSbtPlugin("io.get-coursier" % "sbt-coursier" % "1.1.0-M6")
+addSbtPlugin("io.get-coursier" % "sbt-coursier" % "1.1.0-M12") // if not upgraded from 1.1.0-M6 the dependency resolution fails


### PR DESCRIPTION
As part of #1216 https://github.com/scalacenter/scalafix/issues/1216 this pr demonstrates that version 0.10.1 is still affected by the bug.
Do not merge.