### PR TITLE
fix: remove sbt-coursier

### DIFF
--- a/project/project/plugins.sbt
+++ b/project/project/plugins.sbt
@@ -1,1 +1,0 @@
-addSbtPlugin("io.get-coursier" % "sbt-coursier" % "1.1.0-M6")


### PR DESCRIPTION
This isn't needed and it's causing Scala Steward to throw up when it runs on this repo.